### PR TITLE
includeResizeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ to provide documentation for other elements.
 To export a KDoc comment as HTML, you can use the `@ExportAsHtml` annotation.
 Create an annotation class named exactly "`ExportAsHtml`" and add the arguments `theme: Boolean` and 
 `stripReferences: Boolean` (default both to `true`)
-(you can copy the code from [here](./kodex-common/src/main/kotlin/nl/jolanrensen/kodex/ExportAsHtml.kt)).
+(you can copy the code from [here](./kodex-common/src/main/kotlin/nl/jolanrensen/kodex/annotations/ExportAsHtml.kt)).
 Then, add the annotation to the element you want to export as HTML.
 
 Inside the KDoc comment, you can mark a range of text to be exported as HTML by using the optional `@exportAsHtmlStart` 

--- a/kodex-common/src/main/kotlin/nl/jolanrensen/kodex/annotations/ExportAsHtml.kt
+++ b/kodex-common/src/main/kotlin/nl/jolanrensen/kodex/annotations/ExportAsHtml.kt
@@ -30,6 +30,8 @@ import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
  * @param stripReferences Whether to strip `[references]` from the HTML file. Default is `true`.
  *  This is useful when you want to include the HTML file in a website, where the references are not
  *  needed or would break.
+ * @param includeResizeScript Whether to include a script that helps height recalculation inside iFrames.
+ *  This is useful inside WriterSide. Default is `true`.
  */
 @Target(
     CLASS,
@@ -46,4 +48,4 @@ import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
     TYPEALIAS,
     FILE,
 )
-annotation class ExportAsHtml(val theme: Boolean = true, val stripReferences: Boolean = true)
+annotation class ExportAsHtml(val theme: Boolean = true, val stripReferences: Boolean = true, val includeResizeScript: Boolean = true)

--- a/kodex-common/src/main/kotlin/nl/jolanrensen/kodex/html/HtmlRendering.kt
+++ b/kodex-common/src/main/kotlin/nl/jolanrensen/kodex/html/HtmlRendering.kt
@@ -16,7 +16,7 @@ import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 
-fun DocContent.renderToHtml(theme: Boolean, stripReferences: Boolean): String {
+fun DocContent.renderToHtml(theme: Boolean, stripReferences: Boolean, includeResizeScript: Boolean): String {
     // TODO https://github.com/JetBrains/markdown
     val flavour = GFMFlavourDescriptor(
         useSafeLinks = false,
@@ -103,6 +103,54 @@ fun DocContent.renderToHtml(theme: Boolean, stripReferences: Boolean): String {
                 """.trimIndent(),
             )
             appendLine("</style>")
+            if (includeResizeScript) {
+                @Language("html")
+                val b = appendLine(
+                    """
+                        <script>
+                            function sendHeight() {
+                                const body = document.body;
+                                const html = document.documentElement;
+
+                                const height = Math.max(
+                                    body.scrollHeight,
+                                    body.offsetHeight,
+                                    html.clientHeight,
+                                    html.scrollHeight,
+                                    html.offsetHeight
+                                );
+
+                                parent.postMessage({ type: 'iframeHeight', height }, '*');
+                            }
+
+
+                            function repeatHeightCalculation(maxRetries = 10, interval = 100) {
+                                let retries = 0;
+                                const intervalId = setInterval(() => {
+                                    sendHeight();
+                                    retries++;
+                                    if (retries >= maxRetries) clearInterval(intervalId);
+                                }, interval);
+                            }
+
+                            window.addEventListener('load', () => {
+                                repeatHeightCalculation();
+                            });
+
+
+                            const observer = new MutationObserver(() => repeatHeightCalculation(5, 50));
+                            observer.observe(document.body, {
+                                childList: true,
+                                subtree: true,
+                                characterData: true,
+                                attributes: true
+                            });
+
+                            window.addEventListener('resize', sendHeight);
+                        </script>
+                    """.trimIndent()
+                )
+            }
             appendLine("</head>")
         }
         appendLine(body)

--- a/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/RunKodexAction.kt
+++ b/kodex-gradle-plugin/src/main/kotlin/nl/jolanrensen/kodex/RunKodexAction.kt
@@ -330,9 +330,18 @@ abstract class RunKodexAction {
                 ?.second as? Boolean?
                 ?: true
 
+            val includeResizeScript = exportHtmlAnnotation.arguments
+                .firstOrNull { (it, _) -> it == ExportAsHtml::includeResizeScript.name }
+                ?.second as? Boolean?
+                ?: true
+
             val html = doc
                 .getDocContentForHtmlRange()
-                .renderToHtml(theme = addTheme, stripReferences = stripReferences)
+                .renderToHtml(
+                    theme = addTheme,
+                    stripReferences = stripReferences,
+                    includeResizeScript = includeResizeScript,
+                )
             val targetFile = File(htmlDir, doc.fullyQualifiedPath + ".html")
             try {
                 targetFile.apply {

--- a/kodex-intellij-plugin/src/main/kotlin/nl/jolanrensen/kodex/syntaxHighlighting/ExportAsHtmlAnnotator.kt
+++ b/kodex-intellij-plugin/src/main/kotlin/nl/jolanrensen/kodex/syntaxHighlighting/ExportAsHtmlAnnotator.kt
@@ -128,7 +128,7 @@ private fun exportToHtmlFile(annotationArguments: List<ValueArgument>, doc: Docu
 
     val html = doc
         .getDocContentForHtmlRange()
-        .renderToHtml(theme = theme, stripReferences = stripReferences)
+        .renderToHtml(theme = theme, stripReferences = stripReferences, includeResizeScript = false)
     val file = File.createTempFile(doc.fullyQualifiedPath, ".html")
     file.writeText(html)
 


### PR DESCRIPTION
fixes https://github.com/Jolanrensen/KoDEx/issues/86

Added includeResizeScript option to `ExportAsHtml`, which when true fixes height recalculation in inline-frame in WriterSide